### PR TITLE
add report endpoint, fix badimages property

### DIFF
--- a/src/collector/serializers.py
+++ b/src/collector/serializers.py
@@ -12,9 +12,27 @@ class TranscriptionDataSerializer(serializers.ModelSerializer):
 
 
 class PuzzlePieceSerializer(serializers.ModelSerializer):
+    badimages = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = models.PuzzlePiece
-        fields = ['id', 'url', 'approved', 'confidences', 'confidentsolutions', 'badimages', 'rotatedimages', 'transCount']
+        fields = [
+            'id', 'url', 'approved',
+            'confidences', 'confidentsolutions',
+            'badimages', 'rotatedimages',
+            'transCount'
+        ]
+
+    def get_badimages(self, piece):
+        # check if queryset was annotated
+        if hasattr(piece, 'badimage_count'):
+            return piece.badimage_count
+
+        # queryset wasn't annotated, do the slow thing
+        if piece.badimages.count() > 0:
+            return piece.badimages.first().badCount
+
+        return 0
 
 
 class BadImageSerializer(serializers.ModelSerializer):

--- a/src/collector/views.py
+++ b/src/collector/views.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from django.template import loader
 from django.shortcuts import get_object_or_404, render
 from django.views import generic
-from django.db.models import Count
+from django.db.models import Count, F, Max
 from django.conf import settings
 from .models import *
 from .serializers import (
@@ -507,7 +507,10 @@ def confidenceSolutionDetail(request, solution_id):
 
 
 class PuzzlePieceViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = PuzzlePiece.objects.all()
+    # annotate badimages count for serializer performance
+    queryset = PuzzlePiece.objects.all().annotate(
+        badimage_count=Max('badimages__badCount'),
+    )
     serializer_class = PuzzlePieceSerializer
 
     @action(detail=False)
@@ -522,6 +525,22 @@ class PuzzlePieceViewSet(viewsets.ReadOnlyModelViewSet):
         random_index = randint(0, count - 1)
         rando = qs[random_index]
         serializer = self.get_serializer(rando)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=['post'])
+    def report(self, request, *args, **kwargs):
+        piece = self.get_object()
+        if piece.badimages.count() > 0:
+            # atomic increment of the count on all existing BadImages
+            piece.badimages.update(badCount=F('badCount')+1)
+        else:
+            # create a BadImage... might have a race condition :(
+            bad = BadImage(puzzlePiece=piece, badCount=1)
+            bad.save()
+
+        # go ahead and return the updated piece
+        piece = self.get_object()
+        serializer = self.get_serializer(piece)
         return Response(serializer.data)
 
 


### PR DESCRIPTION
`POST /pieces/{id}/report/`, content doesn't matter, return value is the piece with the increased count.

A few notes here:
1) Like the other endpoints, this one requires a / at the end. There's a Django setting for changing that somewhere...
2) There's no race conditions if the piece already has a BadImage model, but if it doesn't it could create two. Everything should still function fine but it wouldn't be increased twice. Make sure to debounce them buttons.
3) **The `badimages` is no longer a list**, but it didn't have the right value in it anyways.
4) The proper badimages value should be speedy **when the queryset is annotated properly**. If it's not, it will do a query for each puzzle piece to find the value.